### PR TITLE
docs: Replace CircleCI badge with Github badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > A simple Java API client for the Ark Blockchain.
 
-[![Build Status](https://badgen.now.sh/circleci/github/ArkEcosystem/java-client)](https://circleci.com/gh/ArkEcosystem/java-client)
+[![Build Status](https://badgen.net/github/status/ArkEcosystem/java-client)](https://github.com/ArkEcosystem/java-client/actions/)
 [![Codecov](https://badgen.now.sh/codecov/c/github/arkecosystem/java-client)](https://codecov.io/gh/arkecosystem/java-client)
 [![Latest Version](https://badgen.now.sh/github/release/ArkEcosystem/java-client)](https://github.com/ArkEcosystem/java-client/releases)
 [![License: MIT](https://badgen.now.sh/badge/license/MIT/green)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
CircleCI build removed in 1cd612c02236dbad3b354253302c693979a1aa7d, but failing badge have been kept in readme.
I have replaced CircleCI badge with Github Actions badge.
<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [x] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
Resolves #153 
